### PR TITLE
#44 Combobox 

### DIFF
--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -14,6 +14,10 @@ interface ComboboxContextProps {
    * Change the open state of the combobox
    */
   toggle: () => void;
+  /**
+   * Change the open state of the combobox
+   */
+  changeIsOpen: (value: boolean) => void;
 }
 
 export const ComboboxContext = createContext<ComboboxContextProps | null>(null);
@@ -32,10 +36,16 @@ export const ComboboxProvider = ({
 }: ComboboxProviderProps) => {
   const [currentValue, changeCurrent] = useState(current ?? 0);
 
-  const { isOpen, toggle } = useToggle();
+  const { isOpen, toggle, changeIsOpen } = useToggle();
 
   const ContextValue = useMemo(
-    () => ({ current: currentValue, changeCurrent, isOpen, toggle }),
+    () => ({
+      current: currentValue,
+      changeCurrent,
+      isOpen,
+      toggle,
+      changeIsOpen,
+    }),
     [currentValue, current, isOpen]
   );
 

--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -43,7 +43,6 @@ export const ComboboxProvider = ({
 }: ComboboxProviderProps) => {
   const [currentValue, changeCurrent] = useState(current ?? "");
 
-  console.log(currentValue);
   const { isOpen, toggle, changeIsOpen } = useToggle();
 
   const ContextValue = useMemo(

--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -18,6 +18,10 @@ interface ComboboxContextProps {
    * Change the open state of the combobox
    */
   changeIsOpen: (value: boolean) => void;
+  /**
+   * Change the current selected option index.
+   */
+  changeCurrent: (value: number) => void;
 }
 
 export const ComboboxContext = createContext<ComboboxContextProps | null>(null);

--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -1,0 +1,33 @@
+import { ReactNode, createContext, useMemo, useState } from "react";
+
+interface ComboboxContextProps {
+  /**
+   * The current selected option index.
+   */
+  current?: number;
+}
+
+export const ComboboxContext = createContext<ComboboxContextProps | null>(null);
+
+interface ComboboxProviderProps {
+  children: ReactNode;
+  current?: number;
+}
+
+export const ComboboxProvider = ({
+  children,
+  current,
+}: ComboboxProviderProps) => {
+  const [currentValue, changeCurrent] = useState(current ?? 0);
+
+  const ContextValue = useMemo(
+    () => ({ current: currentValue, changeCurrent }),
+    [currentValue, current]
+  );
+
+  return (
+    <ComboboxContext.Provider value={ContextValue}>
+      {children}
+    </ComboboxContext.Provider>
+  );
+};

--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -1,3 +1,4 @@
+import { useToggle } from "../../hooks/use-toggle";
 import { ReactNode, createContext, useMemo, useState } from "react";
 
 interface ComboboxContextProps {
@@ -5,12 +6,23 @@ interface ComboboxContextProps {
    * The current selected option index.
    */
   current?: number;
+  /**
+   * The open satet of the combobox
+   */
+  isOpen: boolean;
+  /**
+   * Change the open state of the combobox
+   */
+  toggle: () => void;
 }
 
 export const ComboboxContext = createContext<ComboboxContextProps | null>(null);
 
 interface ComboboxProviderProps {
   children: ReactNode;
+  /**
+   * The current selected option index.
+   */
   current?: number;
 }
 
@@ -20,9 +32,11 @@ export const ComboboxProvider = ({
 }: ComboboxProviderProps) => {
   const [currentValue, changeCurrent] = useState(current ?? 0);
 
+  const { isOpen, toggle } = useToggle();
+
   const ContextValue = useMemo(
-    () => ({ current: currentValue, changeCurrent }),
-    [currentValue, current]
+    () => ({ current: currentValue, changeCurrent, isOpen, toggle }),
+    [currentValue, current, isOpen]
   );
 
   return (

--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -3,9 +3,10 @@ import { ReactNode, createContext, useMemo, useState } from "react";
 
 interface ComboboxContextProps {
   /**
-   * The current selected option index.
+   * The current selected option value
+   * @type string
    */
-  current?: number;
+  current?: string;
   /**
    * The open satet of the combobox
    */
@@ -19,9 +20,10 @@ interface ComboboxContextProps {
    */
   changeIsOpen: (value: boolean) => void;
   /**
-   * Change the current selected option index.
+   * Change the current selected option value
+   * @param value - the value of the selected option
    */
-  changeCurrent: (value: number) => void;
+  changeCurrent: (value: string) => void;
 }
 
 export const ComboboxContext = createContext<ComboboxContextProps | null>(null);
@@ -29,17 +31,19 @@ export const ComboboxContext = createContext<ComboboxContextProps | null>(null);
 interface ComboboxProviderProps {
   children: ReactNode;
   /**
-   * The current selected option index.
+   * The current selected option value.
+   * @type string
    */
-  current?: number;
+  current?: string;
 }
 
 export const ComboboxProvider = ({
   children,
   current,
 }: ComboboxProviderProps) => {
-  const [currentValue, changeCurrent] = useState(current ?? 0);
+  const [currentValue, changeCurrent] = useState(current ?? "");
 
+  console.log(currentValue);
   const { isOpen, toggle, changeIsOpen } = useToggle();
 
   const ContextValue = useMemo(

--- a/packages/hj-design-system/components/combobox/combobox-context.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-context.tsx
@@ -24,6 +24,16 @@ interface ComboboxContextProps {
    * @param value - the value of the selected option
    */
   changeCurrent: (value: string) => void;
+  /**
+   * The current selected option index
+   * @type number
+   */
+  currentIndex: number;
+  /**
+   * Change the current selected option index
+   * @param index - the index of the selected option
+   */
+  changeCurrentIndex: (index: number) => void;
 }
 
 export const ComboboxContext = createContext<ComboboxContextProps | null>(null);
@@ -43,6 +53,8 @@ export const ComboboxProvider = ({
 }: ComboboxProviderProps) => {
   const [currentValue, changeCurrent] = useState(current ?? "");
 
+  const [currentIndex, changeCurrentIndex] = useState(-1);
+
   const { isOpen, toggle, changeIsOpen } = useToggle();
 
   const ContextValue = useMemo(
@@ -52,8 +64,10 @@ export const ComboboxProvider = ({
       isOpen,
       toggle,
       changeIsOpen,
+      currentIndex,
+      changeCurrentIndex,
     }),
-    [currentValue, current, isOpen]
+    [currentValue, current, isOpen, currentIndex]
   );
 
   return (

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -1,0 +1,26 @@
+import { ForwardedRef, HTMLAttributes, forwardRef, useContext } from "react";
+import { ComboboxContext } from "./combobox-context";
+
+type ComboboxInput = HTMLAttributes<HTMLInputElement>;
+
+export const ComboboxInput = forwardRef(function ComboboxInput(
+  props: ComboboxInput,
+  ref: ForwardedRef<HTMLInputElement>
+) {
+  const comboboxContext = useContext(ComboboxContext);
+
+  if (!comboboxContext) {
+    throw new Error("Combobox.Input should be used within a Combobox.Root");
+  }
+
+  return (
+    <input
+      {...props}
+      ref={ref}
+      role="combobox"
+      onFocus={() => comboboxContext.changeIsOpen(true)}
+      onBlur={() => comboboxContext.changeIsOpen(false)}
+      aria-expanded={comboboxContext.isOpen}
+    />
+  );
+});

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -19,8 +19,8 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
       ref={ref}
       role="combobox"
       onFocus={() => comboboxContext.changeIsOpen(true)}
-      onBlur={() => comboboxContext.changeIsOpen(false)}
       aria-expanded={comboboxContext.isOpen}
+      value={comboboxContext.current}
     />
   );
 });

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -26,18 +26,23 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
     if (!comboboxContext) return;
     const inputTarget = e.target as HTMLInputElement;
     if (!inputTarget.nextSibling) return;
-    const optionsLength = (inputTarget.nextSibling as HTMLElement).children
-      .length;
+    const options = (inputTarget.nextSibling as HTMLElement).children;
 
     if (e.key === "ArrowDown") {
-      const nextIndex = (comboboxContext.currentIndex + 1) % optionsLength;
+      const nextIndex = (comboboxContext.currentIndex + 1) % options.length;
       comboboxContext?.changeCurrentIndex(nextIndex);
     } else if (e.key === "ArrowUp") {
       if (comboboxContext.currentIndex === 0) {
-        comboboxContext?.changeCurrentIndex(optionsLength - 1);
+        comboboxContext?.changeCurrentIndex(options.length - 1);
       } else {
         comboboxContext?.changeCurrentIndex(comboboxContext.currentIndex - 1);
       }
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      comboboxContext?.changeCurrent(
+        (options[comboboxContext.currentIndex] as HTMLElement).outerText
+      );
+      comboboxContext?.changeIsOpen(false);
     }
   };
 

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -23,10 +23,22 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
   const comboboxContext = useContext(ComboboxContext);
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "ArrowDown")
-      comboboxContext?.changeCurrentIndex(comboboxContext.currentIndex + 1);
-    else if (e.key === "ArrowUp")
-      comboboxContext?.changeCurrentIndex(comboboxContext.currentIndex - 1);
+    if (!comboboxContext) return;
+    const inputTarget = e.target as HTMLInputElement;
+    if (!inputTarget.nextSibling) return;
+    const optionsLength = (inputTarget.nextSibling as HTMLElement).children
+      .length;
+
+    if (e.key === "ArrowDown") {
+      const nextIndex = (comboboxContext.currentIndex + 1) % optionsLength;
+      comboboxContext?.changeCurrentIndex(nextIndex);
+    } else if (e.key === "ArrowUp") {
+      if (comboboxContext.currentIndex === 0) {
+        comboboxContext?.changeCurrentIndex(optionsLength - 1);
+      } else {
+        comboboxContext?.changeCurrentIndex(comboboxContext.currentIndex - 1);
+      }
+    }
   };
 
   const styles = useMemo(() => {

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -3,6 +3,7 @@
 import {
   ForwardedRef,
   HTMLAttributes,
+  KeyboardEvent,
   forwardRef,
   useContext,
   useMemo,
@@ -21,6 +22,13 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
   const comboboxContext = useContext(ComboboxContext);
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "ArrowDown")
+      comboboxContext?.changeCurrentIndex(comboboxContext.currentIndex + 1);
+    else if (e.key === "ArrowUp")
+      comboboxContext?.changeCurrentIndex(comboboxContext.currentIndex - 1);
+  };
+
   const styles = useMemo(() => {
     return style ? [inputBaseStyle, css({ ...style })] : inputBaseStyle;
   }, [style, inputBaseStyle]);
@@ -36,6 +44,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
       role="combobox"
       onFocus={() => comboboxContext.changeIsOpen(true)}
       onChange={(e) => comboboxContext.changeCurrent(e.target.value)}
+      onKeyDown={handleKeyDown}
       aria-expanded={comboboxContext.isOpen}
       value={comboboxContext.current}
       css={styles}

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -19,6 +19,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
       ref={ref}
       role="combobox"
       onFocus={() => comboboxContext.changeIsOpen(true)}
+      onChange={(e) => comboboxContext.changeCurrent(e.target.value)}
       aria-expanded={comboboxContext.isOpen}
       value={comboboxContext.current}
     />

--- a/packages/hj-design-system/components/combobox/combobox-input.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-input.tsx
@@ -1,5 +1,15 @@
-import { ForwardedRef, HTMLAttributes, forwardRef, useContext } from "react";
+/** @jsxImportSource @emotion/react */
+
+import {
+  ForwardedRef,
+  HTMLAttributes,
+  forwardRef,
+  useContext,
+  useMemo,
+} from "react";
 import { ComboboxContext } from "./combobox-context";
+import { inputBaseStyle } from "./styles/combobox-input";
+import { css } from "@emotion/react";
 
 type ComboboxInput = HTMLAttributes<HTMLInputElement>;
 
@@ -7,7 +17,13 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
   props: ComboboxInput,
   ref: ForwardedRef<HTMLInputElement>
 ) {
+  const { style, ...rest } = props;
+
   const comboboxContext = useContext(ComboboxContext);
+
+  const styles = useMemo(() => {
+    return style ? [inputBaseStyle, css({ ...style })] : inputBaseStyle;
+  }, [style, inputBaseStyle]);
 
   if (!comboboxContext) {
     throw new Error("Combobox.Input should be used within a Combobox.Root");
@@ -15,13 +31,14 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
   return (
     <input
-      {...props}
+      {...rest}
       ref={ref}
       role="combobox"
       onFocus={() => comboboxContext.changeIsOpen(true)}
       onChange={(e) => comboboxContext.changeCurrent(e.target.value)}
       aria-expanded={comboboxContext.isOpen}
       value={comboboxContext.current}
+      css={styles}
     />
   );
 });

--- a/packages/hj-design-system/components/combobox/combobox-item.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-item.tsx
@@ -1,0 +1,38 @@
+import {
+  PolymorphicComponentPropsWithRef,
+  PolymorphicRef,
+} from "components/polymorphic";
+import { ElementType, forwardRef, useContext } from "react";
+import { ComboboxContext } from "./combobox-context";
+
+type ComboboxItemProps<C extends ElementType = "li"> =
+  PolymorphicComponentPropsWithRef<C>;
+
+export const ComboboxItem = forwardRef(function ComboboxItem<
+  C extends ElementType = "li",
+>(props: ComboboxItemProps<C>, ref?: PolymorphicRef<C>) {
+  const { as, children, handleChange, onClick, index, ...rest } = props;
+  const Component = as || "li";
+
+  const comboboxContext = useContext(ComboboxContext);
+
+  if (!comboboxContext) {
+    throw new Error("Combobox.Item should be used within a Combobox.Root");
+  }
+
+  return (
+    <Component
+      ref={ref}
+      role="option"
+      onClick={() => {
+        handleChange();
+        comboboxContext.changeIsOpen(false);
+        onClick?.();
+      }}
+      aria-selectd={comboboxContext.current === index}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+});

--- a/packages/hj-design-system/components/combobox/combobox-item.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-item.tsx
@@ -6,14 +6,25 @@ import { ElementType, forwardRef, useContext } from "react";
 import { ComboboxContext } from "./combobox-context";
 
 type ComboboxItemProps<C extends ElementType = "li"> =
-  PolymorphicComponentPropsWithRef<C>;
+  PolymorphicComponentPropsWithRef<
+    C,
+    {
+      /**
+       * The value of the option
+       */
+      value: string;
+      /**
+       * change handler
+       */
+      handleChange?: (index: string) => void;
+    }
+  >;
 
 export const ComboboxItem = forwardRef(function ComboboxItem<
   C extends ElementType = "li",
 >(props: ComboboxItemProps<C>, ref?: PolymorphicRef<C>) {
-  const { as, children, handleChange, onClick, index, ...rest } = props;
+  const { as, children, handleChange, onClick, value, index, ...rest } = props;
   const Component = as || "li";
-
   const comboboxContext = useContext(ComboboxContext);
 
   if (!comboboxContext) {
@@ -24,14 +35,14 @@ export const ComboboxItem = forwardRef(function ComboboxItem<
     <Component
       ref={ref}
       role="option"
-      onClick={() => {
-        handleChange();
+      onClick={(e) => {
+        handleChange?.(value);
+        onClick?.(e);
         comboboxContext.changeIsOpen(false);
-        onClick?.();
       }}
-      aria-selectd={comboboxContext.current === index}
       {...rest}
     >
+      {value}
       {children}
     </Component>
   );

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource @emotion/react */
+
 import {
   PolymorphicComponentPropsWithRef,
   PolymorphicRef,
@@ -10,10 +12,12 @@ import {
   forwardRef,
   isValidElement,
   useContext,
+  useMemo,
 } from "react";
 import { ComboboxContext } from "./combobox-context";
 import { AnimatePresenceProps, motion } from "framer-motion";
 import { defaultAnimationVariants } from "../../theme/foundations/animation";
+import { listBaseStyle } from "./styles/combobox-list";
 
 type ComboboxListProps<C extends ElementType = "ul"> =
   PolymorphicComponentPropsWithRef<
@@ -34,12 +38,22 @@ type ComboboxListProps<C extends ElementType = "ul"> =
 export const ComboboxList = forwardRef(function ComboboxList<
   C extends ElementType = "ul",
 >(props: ComboboxListProps<C>, ref: PolymorphicRef<C>) {
-  const { as, children, disableAnimation, animatePresenceProps, ...rest } =
-    props;
+  const {
+    as,
+    children,
+    disableAnimation,
+    animatePresenceProps,
+    style,
+    ...rest
+  } = props;
 
   const comboboxContext = useContext(ComboboxContext);
 
   const Copmonent = disableAnimation ? as || "ul" : motion(as || "ul");
+
+  const styles = useMemo(() => {
+    return style ? [listBaseStyle, style] : listBaseStyle;
+  }, [listBaseStyle, style]);
 
   if (!comboboxContext) {
     throw new Error("Combobox.List should be used within a Combobox.Root");
@@ -54,6 +68,7 @@ export const ComboboxList = forwardRef(function ComboboxList<
           animate={!disableAnimation ? "animate" : undefined}
           variants={!disableAnimation ? defaultAnimationVariants : undefined}
           tabIndex={0}
+          css={styles}
           {...rest}
         >
           {Children.map(children, (child) => {

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -1,0 +1,67 @@
+import {
+  PolymorphicComponentPropsWithRef,
+  PolymorphicRef,
+} from "components/polymorphic";
+import {
+  Children,
+  ElementType,
+  ReactElement,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useContext,
+} from "react";
+import { ComboboxContext } from "./combobox-context";
+import { AnimatePresenceProps, motion } from "framer-motion";
+import { defaultAnimationVariants } from "../../theme/foundations/animation";
+
+type ComboboxListProps<C extends ElementType = "ul"> =
+  PolymorphicComponentPropsWithRef<
+    C,
+    {
+      /**
+       * whether to disable animation
+       * @default false
+       */
+      disableAnimation?: boolean;
+      /**
+       * AnimatePresence props using framer-motion
+       */
+      animatePresenceProps?: AnimatePresenceProps;
+    }
+  >;
+
+export const ComboboxList = forwardRef(function ComboboxList<
+  C extends ElementType = "ul",
+>(props: ComboboxListProps<C>, ref: PolymorphicRef<C>) {
+  const { as, children, disableAnimation, animatePresenceProps, ...rest } =
+    props;
+
+  const comboboxContext = useContext(ComboboxContext);
+
+  const Copmonent = disableAnimation ? as || "ul" : motion(as || "ul");
+
+  if (!comboboxContext) {
+    throw new Error("Combobox.List should be used within a Combobox.Root");
+  }
+
+  return (
+    <>
+      {comboboxContext.isOpen && (
+        <Copmonent
+          ref={ref}
+          role="listbox"
+          animate={!disableAnimation ? "animate" : undefined}
+          variants={!disableAnimation ? defaultAnimationVariants : undefined}
+          animatePresenceProps={animatePresenceProps}
+          {...rest}
+        >
+          {Children.map(children, (child, idx) => {
+            if (!isValidElement(child)) return null;
+            return cloneElement(child as ReactElement);
+          })}
+        </Copmonent>
+      )}
+    </>
+  );
+});

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -71,13 +71,14 @@ export const ComboboxList = forwardRef(function ComboboxList<
           css={styles}
           {...rest}
         >
-          {Children.map(children, (child) => {
+          {Children.map(children, (child, index) => {
             if (!isValidElement(child)) return null;
             return child.props.value
               .toLowerCase()
               .includes(comboboxContext.current?.toLowerCase())
               ? cloneElement(child as ReactElement, {
                   handleChange: comboboxContext.changeCurrent,
+                  index,
                 })
               : null;
           })}

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -53,16 +53,12 @@ export const ComboboxList = forwardRef(function ComboboxList<
           role="listbox"
           animate={!disableAnimation ? "animate" : undefined}
           variants={!disableAnimation ? defaultAnimationVariants : undefined}
-          animatePresenceProps={animatePresenceProps}
           {...rest}
         >
-          {Children.map(children, (child, idx) => {
+          {Children.map(children, (child) => {
             if (!isValidElement(child)) return null;
             return cloneElement(child as ReactElement, {
-              handleChange: () => {
-                comboboxContext.changeCurrent(idx);
-              },
-              index: idx,
+              handleChange: comboboxContext.changeCurrent,
             });
           })}
         </Copmonent>

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -58,7 +58,12 @@ export const ComboboxList = forwardRef(function ComboboxList<
         >
           {Children.map(children, (child, idx) => {
             if (!isValidElement(child)) return null;
-            return cloneElement(child as ReactElement);
+            return cloneElement(child as ReactElement, {
+              handleChange: () => {
+                comboboxContext.changeCurrent(idx);
+              },
+              index: idx,
+            });
           })}
         </Copmonent>
       )}

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -57,9 +57,13 @@ export const ComboboxList = forwardRef(function ComboboxList<
         >
           {Children.map(children, (child) => {
             if (!isValidElement(child)) return null;
-            return cloneElement(child as ReactElement, {
-              handleChange: comboboxContext.changeCurrent,
-            });
+            return child.props.value
+              .toLowerCase()
+              .includes(comboboxContext.current?.toLowerCase())
+              ? cloneElement(child as ReactElement, {
+                  handleChange: comboboxContext.changeCurrent,
+                })
+              : null;
           })}
         </Copmonent>
       )}

--- a/packages/hj-design-system/components/combobox/combobox-list.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-list.tsx
@@ -53,6 +53,7 @@ export const ComboboxList = forwardRef(function ComboboxList<
           role="listbox"
           animate={!disableAnimation ? "animate" : undefined}
           variants={!disableAnimation ? defaultAnimationVariants : undefined}
+          tabIndex={0}
           {...rest}
         >
           {Children.map(children, (child) => {

--- a/packages/hj-design-system/components/combobox/combobox-option.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-option.tsx
@@ -39,6 +39,18 @@ export const ComboboxOption = forwardRef(function ComboboxOption<
     return style ? [baseStyles, style] : baseStyles;
   }, [optionBaseStyle, style]);
 
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      const optionElements = document.querySelectorAll("[role='option']");
+      const activeElement = comboboxContext
+        ? optionElements[comboboxContext.currentIndex]
+        : null;
+      if (activeElement) {
+        activeElement.scrollIntoView({ behavior: "auto", block: "nearest" });
+      }
+    });
+  }, []);
+
   if (!comboboxContext) {
     throw new Error("Combobox.Item should be used within a Combobox.Root");
   }

--- a/packages/hj-design-system/components/combobox/combobox-option.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-option.tsx
@@ -40,6 +40,7 @@ export const ComboboxOption = forwardRef(function ComboboxOption<
         onClick?.(e);
         comboboxContext.changeIsOpen(false);
       }}
+      tabIndex={-1}
       {...rest}
     >
       {value}

--- a/packages/hj-design-system/components/combobox/combobox-option.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-option.tsx
@@ -5,7 +5,7 @@ import {
 import { ElementType, forwardRef, useContext } from "react";
 import { ComboboxContext } from "./combobox-context";
 
-type ComboboxItemProps<C extends ElementType = "li"> =
+type ComboboxOptionProps<C extends ElementType = "li"> =
   PolymorphicComponentPropsWithRef<
     C,
     {
@@ -20,9 +20,9 @@ type ComboboxItemProps<C extends ElementType = "li"> =
     }
   >;
 
-export const ComboboxItem = forwardRef(function ComboboxItem<
+export const ComboboxOption = forwardRef(function ComboboxOption<
   C extends ElementType = "li",
->(props: ComboboxItemProps<C>, ref?: PolymorphicRef<C>) {
+>(props: ComboboxOptionProps<C>, ref?: PolymorphicRef<C>) {
   const { as, children, handleChange, onClick, value, index, ...rest } = props;
   const Component = as || "li";
   const comboboxContext = useContext(ComboboxContext);

--- a/packages/hj-design-system/components/combobox/combobox-option.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-option.tsx
@@ -4,9 +4,9 @@ import {
   PolymorphicComponentPropsWithRef,
   PolymorphicRef,
 } from "components/polymorphic";
-import { ElementType, forwardRef, useContext, useMemo } from "react";
+import { ElementType, forwardRef, useContext, useEffect, useMemo } from "react";
 import { ComboboxContext } from "./combobox-context";
-import { optionBaseStyle } from "./styles/combobox-option";
+import { getSelectedStyle, optionBaseStyle } from "./styles/combobox-option";
 
 type ComboboxOptionProps<C extends ElementType = "li"> =
   PolymorphicComponentPropsWithRef<
@@ -32,7 +32,11 @@ export const ComboboxOption = forwardRef(function ComboboxOption<
   const comboboxContext = useContext(ComboboxContext);
 
   const combinedStyles = useMemo(() => {
-    return style ? [optionBaseStyle, style] : optionBaseStyle;
+    const baseStyles = [
+      optionBaseStyle,
+      getSelectedStyle(comboboxContext?.currentIndex === index),
+    ];
+    return style ? [baseStyles, style] : baseStyles;
   }, [optionBaseStyle, style]);
 
   if (!comboboxContext) {

--- a/packages/hj-design-system/components/combobox/combobox-option.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-option.tsx
@@ -1,9 +1,12 @@
+/** @jsxImportSource @emotion/react */
+
 import {
   PolymorphicComponentPropsWithRef,
   PolymorphicRef,
 } from "components/polymorphic";
-import { ElementType, forwardRef, useContext } from "react";
+import { ElementType, forwardRef, useContext, useMemo } from "react";
 import { ComboboxContext } from "./combobox-context";
+import { optionBaseStyle } from "./styles/combobox-option";
 
 type ComboboxOptionProps<C extends ElementType = "li"> =
   PolymorphicComponentPropsWithRef<
@@ -23,9 +26,14 @@ type ComboboxOptionProps<C extends ElementType = "li"> =
 export const ComboboxOption = forwardRef(function ComboboxOption<
   C extends ElementType = "li",
 >(props: ComboboxOptionProps<C>, ref?: PolymorphicRef<C>) {
-  const { as, children, handleChange, onClick, value, index, ...rest } = props;
+  const { as, children, handleChange, onClick, value, index, style, ...rest } =
+    props;
   const Component = as || "li";
   const comboboxContext = useContext(ComboboxContext);
+
+  const combinedStyles = useMemo(() => {
+    return style ? [optionBaseStyle, style] : optionBaseStyle;
+  }, [optionBaseStyle, style]);
 
   if (!comboboxContext) {
     throw new Error("Combobox.Item should be used within a Combobox.Root");
@@ -41,6 +49,7 @@ export const ComboboxOption = forwardRef(function ComboboxOption<
         comboboxContext.changeIsOpen(false);
       }}
       tabIndex={-1}
+      css={combinedStyles}
       {...rest}
     >
       {value}

--- a/packages/hj-design-system/components/combobox/combobox-root.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-root.tsx
@@ -1,4 +1,5 @@
 import { ForwardedRef, HTMLAttributes, forwardRef } from "react";
+import { ComboboxProvider } from "./combobox-context";
 
 type ComboboxRootProps = HTMLAttributes<HTMLDivElement> & {
   /**
@@ -14,8 +15,10 @@ export const ComboboxRoot = forwardRef(function ComboboxRoot(
   const { children, current, ...rest } = props;
 
   return (
-    <div ref={ref} {...rest}>
-      {children}
-    </div>
+    <ComboboxProvider current={current}>
+      <div ref={ref} {...rest}>
+        {children}
+      </div>
+    </ComboboxProvider>
   );
 });

--- a/packages/hj-design-system/components/combobox/combobox-root.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-root.tsx
@@ -5,7 +5,7 @@ type ComboboxRootProps = HTMLAttributes<HTMLDivElement> & {
   /**
    * The current selected option index.
    */
-  current?: number;
+  current?: string;
 };
 
 export const ComboboxRoot = forwardRef(function ComboboxRoot(

--- a/packages/hj-design-system/components/combobox/combobox-root.tsx
+++ b/packages/hj-design-system/components/combobox/combobox-root.tsx
@@ -1,0 +1,21 @@
+import { ForwardedRef, HTMLAttributes, forwardRef } from "react";
+
+type ComboboxRootProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * The current selected option index.
+   */
+  current?: number;
+};
+
+export const ComboboxRoot = forwardRef(function ComboboxRoot(
+  props: ComboboxRootProps,
+  ref?: ForwardedRef<HTMLDivElement>
+) {
+  const { children, current, ...rest } = props;
+
+  return (
+    <div ref={ref} {...rest}>
+      {children}
+    </div>
+  );
+});

--- a/packages/hj-design-system/components/combobox/combobox.stories.tsx
+++ b/packages/hj-design-system/components/combobox/combobox.stories.tsx
@@ -1,0 +1,23 @@
+// Combobox.stories.tsx
+import React, { ComponentProps } from "react";
+import { Combobox } from ".";
+
+export default {
+  title: "Components/Combobox",
+  component: Combobox,
+};
+
+type Args = ComponentProps<typeof Combobox.Root>;
+
+const Template = (args: Args) => (
+  <Combobox.Root {...args}>
+    <Combobox.Input aria-placeholder="select an option" />
+    <Combobox.List>
+      <Combobox.Option value="Option 1" />
+      <Combobox.Option value="Option 2" />
+      <Combobox.Option value="Option 3" />
+    </Combobox.List>
+  </Combobox.Root>
+);
+
+export const Default = Template.bind({});

--- a/packages/hj-design-system/components/combobox/combobox.test.tsx
+++ b/packages/hj-design-system/components/combobox/combobox.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Combobox } from ".";
+
+describe("Combobox", () => {
+  it("combobox 를 렌더링한다", () => {
+    render(
+      <Combobox.Root>
+        <Combobox.Input />
+        <Combobox.List>
+          <Combobox.Option value="Option 1" />
+          <Combobox.Option value="Option 2" />
+          <Combobox.Option value="Option 3" />
+        </Combobox.List>
+      </Combobox.Root>
+    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("combobox 를 클릭하면 옵션 리스트를 렌더링한다", () => {
+    render(
+      <Combobox.Root>
+        <Combobox.Input />
+        <Combobox.List>
+          <Combobox.Option value="Option 1" />
+          <Combobox.Option value="Option 2" />
+          <Combobox.Option value="Option 3" />
+        </Combobox.List>
+      </Combobox.Root>
+    );
+
+    fireEvent.focus(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    expect(screen.getAllByRole("option").length).toBe(3);
+  });
+
+  it("option 을 클릭하면 선택된 option 이 input 에 렌더링된다", () => {
+    render(
+      <Combobox.Root>
+        <Combobox.Input />
+        <Combobox.List>
+          <Combobox.Option value="Option 1" />
+          <Combobox.Option value="Option 2" />
+          <Combobox.Option value="Option 3" />
+        </Combobox.List>
+      </Combobox.Root>
+    );
+
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("Option 2"));
+    expect(screen.getByRole("combobox")).toHaveValue("Option 2");
+  });
+
+  it("엔터키를 누르면 선택된 option 이 input 에 렌더링된다", () => {
+    render(
+      <Combobox.Root>
+        <Combobox.Input />
+        <Combobox.List>
+          <Combobox.Option value="Option 1" />
+          <Combobox.Option value="Option 2" />
+          <Combobox.Option value="Option 3" />
+        </Combobox.List>
+      </Combobox.Root>
+    );
+
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Enter" });
+    waitFor(() => {
+      expect(screen.getByRole("combobox")).toHaveValue("Option 1");
+    });
+  });
+});

--- a/packages/hj-design-system/components/combobox/index.ts
+++ b/packages/hj-design-system/components/combobox/index.ts
@@ -1,9 +1,11 @@
 import {ComboboxRoot as Root} from './combobox-root';
 import {ComboboxInput as Input} from './combobox-input';
 import {ComboboxList as List} from './combobox-list'
+import {ComboboxItem as Item} from './combobox-item'
 
 export const Combobox = {
     Root,
     Input,
-    List
+    List,
+    Item
 };

--- a/packages/hj-design-system/components/combobox/index.ts
+++ b/packages/hj-design-system/components/combobox/index.ts
@@ -1,11 +1,11 @@
 import {ComboboxRoot as Root} from './combobox-root';
 import {ComboboxInput as Input} from './combobox-input';
 import {ComboboxList as List} from './combobox-list'
-import {ComboboxItem as Item} from './combobox-item'
+import {ComboboxOption as Option} from './combobox-option'
 
 export const Combobox = {
     Root,
     Input,
     List,
-    Item
+    Option
 };

--- a/packages/hj-design-system/components/combobox/index.ts
+++ b/packages/hj-design-system/components/combobox/index.ts
@@ -1,0 +1,7 @@
+import {ComboboxRoot as Root} from './combobox-root';
+import {ComboboxInput as Input} from './combobox-input';
+
+export const Combobox = {
+    Root,
+    Input,
+};

--- a/packages/hj-design-system/components/combobox/index.ts
+++ b/packages/hj-design-system/components/combobox/index.ts
@@ -1,7 +1,9 @@
 import {ComboboxRoot as Root} from './combobox-root';
 import {ComboboxInput as Input} from './combobox-input';
+import {ComboboxList as List} from './combobox-list'
 
 export const Combobox = {
     Root,
     Input,
+    List
 };

--- a/packages/hj-design-system/components/combobox/styles/combobox-input.ts
+++ b/packages/hj-design-system/components/combobox/styles/combobox-input.ts
@@ -1,0 +1,12 @@
+import { css } from "@emotion/react";
+import { foundations } from "../../../theme/foundations";
+
+export const inputBaseStyle = css({
+    padding: foundations.sizes["2.5"],
+    borderRadius: foundations.radii.md,
+    border: `1px solid ${foundations.colors.gray[300]}`,
+    outline: 'none',
+    ":focus": {
+        borderColor: foundations.colors.gray[600]
+    },
+})

--- a/packages/hj-design-system/components/combobox/styles/combobox-input.ts
+++ b/packages/hj-design-system/components/combobox/styles/combobox-input.ts
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import { foundations } from "../../../theme/foundations";
 
 export const inputBaseStyle = css({
+    position: 'relative',
     padding: foundations.sizes["2.5"],
     borderRadius: foundations.radii.md,
     border: `1px solid ${foundations.colors.gray[300]}`,

--- a/packages/hj-design-system/components/combobox/styles/combobox-list.ts
+++ b/packages/hj-design-system/components/combobox/styles/combobox-list.ts
@@ -1,0 +1,18 @@
+import { css } from "@emotion/react";
+import { foundations } from "../../../theme/foundations";
+
+export const listBaseStyle = css({
+    position: 'absolute',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: foundations.space[4],
+    marginInlineStart: foundations.space[2],
+    padding: foundations.space[2],
+    width: '250px',
+    height: '300px',
+    overflow: 'scroll',
+    listStyle: 'none',
+    background: foundations.colors.white,
+    borderRadius: foundations.radii.md,
+    border: `1px solid ${foundations.colors.gray[300]}`,
+})

--- a/packages/hj-design-system/components/combobox/styles/combobox-option.ts
+++ b/packages/hj-design-system/components/combobox/styles/combobox-option.ts
@@ -10,3 +10,9 @@ export const optionBaseStyle = css({
         background: foundations.colors.blue[200],
     },
 })
+
+export const getSelectedStyle = (isSelected: boolean) => {
+    return css({
+        background: isSelected ? foundations.colors.blue[400] : "transparent",
+    })
+}

--- a/packages/hj-design-system/components/combobox/styles/combobox-option.ts
+++ b/packages/hj-design-system/components/combobox/styles/combobox-option.ts
@@ -2,6 +2,11 @@ import { css } from "@emotion/react";
 import { foundations } from "../../../theme/foundations";
 
 export const optionBaseStyle = css({
+    padding: foundations.space[2],  
     fontSize: foundations.fontSizes.md,
     color: foundations.colors.black,
+    borderRadius: foundations.radii.md,
+    ":hover": {
+        background: foundations.colors.blue[200],
+    },
 })

--- a/packages/hj-design-system/components/combobox/styles/combobox-option.ts
+++ b/packages/hj-design-system/components/combobox/styles/combobox-option.ts
@@ -1,0 +1,7 @@
+import { css } from "@emotion/react";
+import { foundations } from "../../../theme/foundations";
+
+export const optionBaseStyle = css({
+    fontSize: foundations.fontSizes.md,
+    color: foundations.colors.black,
+})

--- a/packages/hj-design-system/components/index.tsx
+++ b/packages/hj-design-system/components/index.tsx
@@ -5,3 +5,4 @@ export * from "./portal";
 export * from "./menu";
 export * from "./icon";
 export * from "./tabs";
+export * from "./combobox";


### PR DESCRIPTION
# Anatomy

![image](https://github.com/f-lab-edu/design-hub/assets/84058944/b901cc7c-57d5-44ea-9ac8-2a32b76d4611)


# Combobox vs Autocomplete

## Combobox
콤보 박스는 연결된 팝업이 있는 입력 위젯입니다. 이 팝업을 통해 사용자는 컬렉션에서 입력 값을 선택합니다.  
콤보 박스는 텍스트 입력을 지원하거나, 지원하지 않는 방식을 가집니다.   
콤보 박스가 텍스트 입력을 지원하지 않는 경우 이를 선택 전용이라고 하며, 사용자가 값을 설정하는 유일한 방법은 팝업에서 값을 선택하는 것입니다.  
콤보 박스가 텍스트 입력을 지원하는 것을 편집 가능이라고 합니다. 편집 가능한 콤보 박스는 사용자가 임의의 값을 입력할 수 있거나, 값들의 집합을 제한할 수 있습니다. 팝업에 표시되는 제안을 필터링하는 역할을 합니다.  

## Autocomplete
Autocomplete 에 대한 공식적인 정의는 찾지 못했습니다. 다만, `콤보 박스가 텍스트 입력을 지원하면서 자동 완성 기능까지 포함`할때 이것을 Autocomplete 이라는 컴포넌트로 모듈화해서 사용한다고 이해했습니다.


저는 확장성을 고려하여 자동 완성 기능이 지원되는 `Combobox` 를 생성했습니다!

---

참고: 
- https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
- https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/